### PR TITLE
Removed the mockup link because it is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ## Design Resources
 
 * [Wireframes](https://sketch.cloud/s/45Dzo)
-* [Mockups](https://philkuo.com/hack4impact/c2tc_mockup_current/)
 * [Prototype](https://sketch.cloud/s/AJ9Ky/PrjlrQ/play)
 
 ## Backend Resources


### PR DESCRIPTION
It should be back online soon, the server hosting the website is currently down. Let's remove the link temporarily. 